### PR TITLE
feat/33 intro_page_scaffold

### DIFF
--- a/static/intro_color_test.css
+++ b/static/intro_color_test.css
@@ -1,0 +1,72 @@
+/* Intro Color Test — minimal, reusable scaffold styles
+   SRP: basic layout + readable defaults for the intro page only.
+   Keep tiny for an incremental commit; heavier styling comes later. */
+
+:root {
+  --bg: #f5f6fa;
+  --text: #111;
+  --card: #fff;
+  --shadow: 0 2px 16px rgba(0, 0, 0, 0.06);
+  --radius: 16px;
+  --pad: 24px;
+  --maxw: 880px;
+}
+
+/* Base document */
+html, body {
+  height: 100%;
+}
+
+body.page-test-intro {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+/* Center the intro section in the viewport */
+#content {
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+}
+
+/* Card container for the intro copy */
+section[aria-labelledby="intro-title"] {
+  width: min(100%, var(--maxw));
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: clamp(16px, 2.5vw, var(--pad));
+}
+
+/* Typographic rhythm */
+#intro-title {
+  margin: 0 0 8px;
+  font-size: clamp(1.25rem, 1.5vw + 1rem, 1.75rem);
+  line-height: 1.25;
+}
+
+section[aria-labelledby="intro-title"] > p {
+  margin: 0 0 16px;
+  color: #333;
+}
+
+/* Primary action */
+#start-test {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 12px 18px;
+  font-weight: 600;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--text);
+  color: #fff;
+}
+
+#start-test:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}

--- a/templates/intro_page_test.html
+++ b/templates/intro_page_test.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{{ test_name|default("Test Intro") }} • SynTest</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/tests.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='intro_color_test.css') }}">
 </head>
 <body class="page-test-intro">
   <main id="content" role="main">
@@ -14,11 +14,10 @@
         {{ subtitle|default("You’ll assign a color to each item, then press Next to save each choice.") }}
       </p>
       <button id="start-test"
-              data-next-href="{{ start_href|default(url_for('main.test_page', slug=test_slug|default('cct'))) }}">
+              data-next-href="{{ start_href|default('#') }}">
         {{ cta_start_label|default("Start") }}
       </button>
     </section>
   </main>
-  <script src="{{ url_for('static', filename='js/tests.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
### What
Front-end scaffold for test Intro page.

### Why
Start the Intro/Outro work with a tiny, reviewable change.

### How
- Add `templates/intro_page_test.html` with title, blurb, Start button.
- Link (future) `static/css/tests.css` and `static/js/tests.js`.

### Acceptance Criteria
- Renders without console errors.
- Start button present (no behavior yet).

### Plan (checklist for follow-ups)
-  Create empty `tests.css` and `tests.js`
-  Add JS to navigate via `data-next-href`
- Add topbar + panel card layout
- 3-column intro layout (instructions / visual / preview)
- [Apply Figma spacing/borders/typography
-  Accessibility pass (focus, aria labels)

This is also an extension.

Refs #31
