### PR TITLE
chore(GitHubWorkflows): enforce PR naming convention

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: naveenk1223/action-pr-title@master
         with:
-          regex: '^[a-zA-Z]+(\([a-zA-Z]+\))?: .+'
+          regex: '^[a-zA-Z]+(\([a-zA-Z\s\\\_\/\-]+\))?: .+'
           allowed_prefixes: "feat,fix,docs,style,refactor,test,chore,ci,perf,revert"
           prefix_case_sensitive: false


### PR DESCRIPTION
This addition to the GitHub repo enforces the `<type>(<optional area of change>): <change>` style PR titles