### PR TITLE
feat(frontend): update lock icon on color tests

### DIFF
--- a/src/components/trigger_color/ColorPreviewLock.jsx
+++ b/src/components/trigger_color/ColorPreviewLock.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Lock, Unlock } from "lucide-react";
 
 /**
  * ColorPreviewLock - Displays selected color preview with lock indicator
@@ -6,8 +7,8 @@ import React from "react";
  * Responsibilities:
  * - Shows a 200x200px square displaying the selected color
  * - Displays hex code in center with contrasting text color
- * - Renders lock/unlock indicator circle below preview
- * - Visual feedback: circle turns red when locked
+ * - Renders lock/unlock icon below preview
+ * - Visual feedback: lock icon changes between locked/unlocked states
  */
 
 export default function ColorPreviewLock({ selected, locked, onToggle }) {
@@ -37,24 +38,33 @@ export default function ColorPreviewLock({ selected, locked, onToggle }) {
         {selected ? selected.hex : "———"}
       </div>
 
-      {/* Lock/unlock indicator circle */}
+      {/* Lock/unlock icon indicator */}
       <div
         onClick={onToggle}
         style={{
           position: "absolute",
-          bottom: "-14px",
+          bottom: "-16px",
           left: "50%",
           transform: "translateX(-50%)",
-          width: "18px",
-          height: "18px",
+          width: "28px",
+          height: "28px",
           borderRadius: "50%",
-          border: "2px solid",
-          borderColor: locked ? "#dc2626" : "#000",
-          backgroundColor: locked ? "#dc2626" : "white",
+          backgroundColor: "white",
+          border: "2px solid #000",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
           cursor: selected ? "pointer" : "default",
+          opacity: selected ? 1 : 0.5,
         }}
         title={locked ? "Click to unlock" : "Click to lock"}
-      />
+      >
+        {locked ? (
+          <Lock size={16} color="#000" strokeWidth={2.5} />
+        ) : (
+          <Unlock size={16} color="#000" strokeWidth={2.5} />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/trigger_color/TestLayout.jsx
+++ b/src/components/trigger_color/TestLayout.jsx
@@ -55,7 +55,7 @@ export default function TestLayout({
           lineHeight: "1.6" 
         }}>
           You'll assign a color to each <strong>{testType}</strong>. <strong>Click and hold</strong> the mouse on the wheel and <strong>drag</strong> to preview and adjust a color.
-          To record a choice, <strong>click to lock</strong> it — the small circle turns <span style={{ color: "#dc2626", fontWeight: "bold" }}>red</span> when locked — and click again to unlock if you need to change it.
+          To record a choice, <strong>click to lock</strong> it — the lock icon appears when locked — and click again to unlock if you need to change it.
           Press <strong>Next</strong> to save each choice. For best results, use a laptop/desktop and turn off blue-light filters.
         </p>
 
@@ -106,7 +106,7 @@ export default function TestLayout({
               maxWidth: "450px", 
               lineHeight: "1.5" 
             }}>
-              Click and hold, then drag to adjust. Click to <strong>lock</strong> (circle turns <span style={{ color: "#dc2626", fontWeight: "bold" }}>red</span>); click again to unlock.
+              Click and hold, then drag to adjust. Click to <strong>lock</strong> (shows lock icon); click again to unlock.
             </p>
           </div>
 


### PR DESCRIPTION
 ## What
- Update the color test instructions to describe the lock **icon** instead of the red circle.
- Adjust the TestLayout/ColorPreviewLock text so it clearly explains how to lock and unlock a choice.

## How
- Edited `TestLayout.jsx` copy to say the lock icon appears when a choice is locked and can be clicked again to unlock.
- Updated `ColorPreviewLock.jsx` label text to match the new behavior/wording.

## Why
- The UI now uses a lock icon to indicate a saved choice, so the instructions and labels should match what users actually see.
- Makes the flow more intuitive and reduces confusion for participants during the color tests.

## Acceptance Criteria
- Instructions for the trigger color tests mention the **lock icon** when describing how to save/lock a choice.
- The lock icon is shown when a choice is locked and the text explains that clicking again will unlock it.
- Only the color test files (`TestLayout.jsx`, `ColorPreviewLock.jsx`) are changed in this PR.
- App builds and runs without errors on `migrate-to-react-2`.

## Results
<img width="1299" height="820" alt="Screenshot 2025-11-24 at 6 08 26 PM" src="https://github.com/user-attachments/assets/4b5f12e7-5ec8-4964-b2cd-16ad52f8fb02" />
